### PR TITLE
Add support for response files with command line arguments.

### DIFF
--- a/src/Microsoft.TestPlatform.Utilities/CommandLineUtilities.cs
+++ b/src/Microsoft.TestPlatform.Utilities/CommandLineUtilities.cs
@@ -1,0 +1,157 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+// Code taken from: https://github.com/dotnet/roslyn/blob/d00363d8f892f4f3c514718a964ea37783d21de5/src/Compilers/Core/Portable/InternalUtilities/CommandLineUtilities.cs
+
+namespace Microsoft.VisualStudio.TestPlatform.Utilities
+{
+    using System.Collections.Generic;
+    using System.Text;
+
+    public static class CommandLineUtilities
+    {
+        /// <summary>
+        /// Split a command line by the same rules as Main would get the commands except the original
+        /// state of backslashes and quotes are preserved.  For example in normal Windows command line 
+        /// parsing the following command lines would produce equivalent Main arguments:
+        /// 
+        ///     - /r:a,b
+        ///     - /r:"a,b"
+        /// 
+        /// This method will differ as the latter will have the quotes preserved.  The only case where 
+        /// quotes are removed is when the entire argument is surrounded by quotes without any inner
+        /// quotes. 
+        /// </summary>
+        /// <remarks>
+        /// Rules for command line parsing, according to MSDN:
+        /// 
+        /// Arguments are delimited by white space, which is either a space or a tab.
+        ///  
+        /// A string surrounded by double quotation marks ("string") is interpreted 
+        /// as a single argument, regardless of white space contained within. 
+        /// A quoted string can be embedded in an argument.
+        ///  
+        /// A double quotation mark preceded by a backslash (\") is interpreted as a 
+        /// literal double quotation mark character (").
+        ///  
+        /// Backslashes are interpreted literally, unless they immediately precede a 
+        /// double quotation mark.
+        ///  
+        /// If an even number of backslashes is followed by a double quotation mark, 
+        /// one backslash is placed in the argv array for every pair of backslashes, 
+        /// and the double quotation mark is interpreted as a string delimiter.
+        ///  
+        /// If an odd number of backslashes is followed by a double quotation mark, 
+        /// one backslash is placed in the argv array for every pair of backslashes, 
+        /// and the double quotation mark is "escaped" by the remaining backslash, 
+        /// causing a literal double quotation mark (") to be placed in argv.
+        /// </remarks>
+        public static IEnumerable<string> SplitCommandLineIntoArguments(string commandLine, bool removeHashComments)
+        {
+            char? unused;
+            return SplitCommandLineIntoArguments(commandLine, removeHashComments, out unused);
+        }
+
+        public static IEnumerable<string> SplitCommandLineIntoArguments(string commandLine, bool removeHashComments, out char? illegalChar)
+        {
+            var builder = new StringBuilder(commandLine.Length);
+            var list = new List<string>();
+            var i = 0;
+
+            illegalChar = null;
+            while (i < commandLine.Length)
+            {
+                while (i < commandLine.Length && char.IsWhiteSpace(commandLine[i]))
+                {
+                    i++;
+                }
+
+                if (i == commandLine.Length)
+                {
+                    break;
+                }
+
+                if (commandLine[i] == '#' && removeHashComments)
+                {
+                    break;
+                }
+
+                var quoteCount = 0;
+                builder.Length = 0;
+                while (i < commandLine.Length && (!char.IsWhiteSpace(commandLine[i]) || (quoteCount % 2 != 0)))
+                {
+                    var current = commandLine[i];
+                    switch (current)
+                    {
+                        case '\\':
+                            {
+                                var slashCount = 0;
+                                do
+                                {
+                                    builder.Append(commandLine[i]);
+                                    i++;
+                                    slashCount++;
+                                } while (i < commandLine.Length && commandLine[i] == '\\');
+
+                                // Slashes not followed by a quote character can be ignored for now
+                                if (i >= commandLine.Length || commandLine[i] != '"')
+                                {
+                                    break;
+                                }
+
+                                // If there is an odd number of slashes then it is escaping the quote
+                                // otherwise it is just a quote.
+                                if (slashCount % 2 == 0)
+                                {
+                                    quoteCount++;
+                                }
+
+                                builder.Append('"');
+                                i++;
+                                break;
+                            }
+
+                        case '"':
+                            builder.Append(current);
+                            quoteCount++;
+                            i++;
+                            break;
+
+                        default:
+                            if ((current >= 0x1 && current <= 0x1f) || current == '|')
+                            {
+                                if (illegalChar == null)
+                                {
+                                    illegalChar = current;
+                                }
+                            }
+                            else
+                            {
+                                builder.Append(current);
+                            }
+
+                            i++;
+                            break;
+                    }
+                }
+
+                // If the quote string is surrounded by quotes with no interior quotes then 
+                // remove the quotes here. 
+                if (quoteCount == 2 && builder[0] == '"' && builder[builder.Length - 1] == '"')
+                {
+                    builder.Remove(0, length: 1);
+                    builder.Remove(builder.Length - 1, length: 1);
+                }
+
+                if (builder.Length > 0)
+                {
+                    list.Add(builder.ToString());
+                }
+            }
+
+            return list;
+        }
+    }
+}

--- a/src/vstest.console/CommandLine/Executor.cs
+++ b/src/vstest.console/CommandLine/Executor.cs
@@ -27,6 +27,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine
     using System.Diagnostics;
     using System.Diagnostics.Contracts;
     using System.Globalization;
+    using System.IO;
     using System.Linq;
     using System.Reflection;
 
@@ -99,9 +100,13 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine
 
             this.PrintSplashScreen();
 
+            // Flatten arguments and process response files.
+            string[] flattenedArguments;
+            exitCode |= this.FlattenArguments(args, out flattenedArguments);
+
             // Get the argument processors for the arguments.
             List<IArgumentProcessor> argumentProcessors;
-            exitCode |= this.GetArgumentProcessors(args, out argumentProcessors);
+            exitCode |= this.GetArgumentProcessors(flattenedArguments, out argumentProcessors);
 
             // Verify that the arguments are valid.
             exitCode |= this.IdentifyDuplicateArguments(argumentProcessors);
@@ -332,6 +337,90 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine
 
             this.Output.WriteLine(CommandLineResources.CopyrightCommandLineTitle, OutputLevel.Information);
             this.Output.WriteLine(string.Empty, OutputLevel.Information);
+        }
+
+        /// <summary>
+        /// Flattens command line arguments by processing response files.
+        /// </summary>
+        /// <param name="arguments">Arguments provided to perform execution with.</param>
+        /// <param name="flattenedArguments">Array of flattened arguments.</param>
+        /// <returns>0 if successful and 1 otherwise.</returns>
+        /// <see href="https://github.com/dotnet/roslyn/blob/bcdcafc2d407635bc7de205d63d0182e81ef9faa/src/Compilers/Core/Portable/CommandLine/CommonCommandLineParser.cs#L297"/>
+        private int FlattenArguments(IEnumerable<string> arguments, out string[] flattenedArguments)
+        {
+            List<string> outputArguments = new List<string>();
+            int result = 0;
+
+            foreach (var arg in arguments)
+            {
+                if (arg.StartsWith("@", StringComparison.Ordinal))
+                {
+                    // response file:
+                    string path = arg.Substring(1).TrimEnd(null);
+                    result |= ParseResponseFile(path, out var responseFileArguments);
+                    outputArguments.AddRange(responseFileArguments.Reverse());
+                }
+                else
+                {
+                    outputArguments.Add(arg);
+                }
+            }
+
+            flattenedArguments = outputArguments.ToArray();
+            return result;
+        }
+
+        /// <summary>
+        /// Parse a response file into a set of arguments. Errors opening the response file are output as errors.
+        /// </summary>
+        /// <param name="fullPath">Full path to the response file.</param>
+        /// <param name="responseFileArguments">Enumeration of the response file arguments.</param>
+        /// <returns>0 if successful and 1 otherwise.</returns>
+        /// <see href="https://github.com/dotnet/roslyn/blob/bcdcafc2d407635bc7de205d63d0182e81ef9faa/src/Compilers/Core/Portable/CommandLine/CommonCommandLineParser.cs#L517"/>
+        private int ParseResponseFile(string fullPath, out IEnumerable<string> responseFileArguments)
+        {
+            int result = 0;
+            List<string> lines = new List<string>();
+            try
+            {
+                using (var reader = new StreamReader(
+                    new FileStream(fullPath, FileMode.Open, FileAccess.Read, FileShare.Read),
+                                   detectEncodingFromByteOrderMarks: true))
+                {
+                    string str;
+                    while ((str = reader.ReadLine()) != null)
+                    {
+                        lines.Add(str);
+                    }
+                }
+
+                responseFileArguments = ParseResponseLines(lines);
+            }
+            catch (Exception)
+            {
+                this.Output.Error(string.Format(CultureInfo.CurrentCulture, CommandLineResources.OpenResponseFileError, fullPath));
+                responseFileArguments = new string[0];
+                result = 1;
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Take a string of lines from a response file, remove comments,
+        /// and split into a set of command line arguments.
+        /// </summary>
+        /// <see href="https://github.com/dotnet/roslyn/blob/bcdcafc2d407635bc7de205d63d0182e81ef9faa/src/Compilers/Core/Portable/CommandLine/CommonCommandLineParser.cs#L545"/>
+        private static IEnumerable<string> ParseResponseLines(IEnumerable<string> lines)
+        {
+            List<string> arguments = new List<string>();
+
+            foreach (string line in lines)
+            {
+                arguments.AddRange(CommandLineUtilities.SplitCommandLineIntoArguments(line, removeHashComments: true));
+            }
+
+            return arguments;
         }
 
         #endregion

--- a/src/vstest.console/Processors/ResponseFileArgumentProcessor.cs
+++ b/src/vstest.console/Processors/ResponseFileArgumentProcessor.cs
@@ -1,0 +1,71 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Processors
+{
+    using System;
+    using System.Diagnostics.Contracts;
+    using System.Globalization;
+    using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+
+    using CommandLineResources = Microsoft.VisualStudio.TestPlatform.CommandLine.Resources.Resources;
+
+    /// <summary>
+    ///  An argument processor that allows the user to specify additional arguments from a response file.
+    ///  for test run.
+    /// </summary>
+    internal class ResponseFileArgumentProcessor : IArgumentProcessor
+    {
+        #region Constants
+
+        /// <summary>
+        /// The name of the command line argument that the OutputArgumentExecutor handles.
+        /// </summary>
+        public const string CommandName = "@";
+
+        #endregion
+
+        private Lazy<IArgumentProcessorCapabilities> metadata;
+
+        /// <summary>
+        /// Gets the metadata.
+        /// </summary>
+        public Lazy<IArgumentProcessorCapabilities> Metadata
+        {
+            get
+            {
+                if (this.metadata == null)
+                {
+                    this.metadata = new Lazy<IArgumentProcessorCapabilities>(() => new ResponseFileArgumentProcessorCapabilities());
+                }
+
+                return this.metadata;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the executor.
+        /// </summary>
+        /// <remarks>
+        /// As this manipulates the command line arguments themselves, this has no executor.
+        /// </remarks>
+        public Lazy<IArgumentExecutor> Executor { get; set; }
+    }
+
+    internal class ResponseFileArgumentProcessorCapabilities : BaseArgumentProcessorCapabilities
+    {
+        public override string CommandName => ResponseFileArgumentProcessor.CommandName;
+
+        public override bool AllowMultiple => true;
+
+        public override bool IsAction => false;
+
+        public override bool IsSpecialCommand => true;
+
+        public override ArgumentProcessorPriority Priority => ArgumentProcessorPriority.Normal;
+
+        public override string HelpContentResourceName => CommandLineResources.ResponseFileArgumentHelp;
+
+        public override HelpContentPriority HelpPriority => HelpContentPriority.ResponseFileArgumentProcessorHelpPriority;
+    }
+}

--- a/src/vstest.console/Processors/Utilities/ArgumentProcessorFactory.cs
+++ b/src/vstest.console/Processors/Utilities/ArgumentProcessorFactory.cs
@@ -229,7 +229,8 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Processors
                 new EnableLoggerArgumentProcessor(),
                 new ParallelArgumentProcessor(),
                 new EnableDiagArgumentProcessor(),
-                new CLIRunSettingsArgumentProcessor()
+                new CLIRunSettingsArgumentProcessor(),
+                new ResponseFileArgumentProcessor(),
         };
 
         /// <summary>

--- a/src/vstest.console/Processors/Utilities/HelpContentPriority.cs
+++ b/src/vstest.console/Processors/Utilities/HelpContentPriority.cs
@@ -124,6 +124,11 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Processors
         EnableDiagArgumentProcessorHelpPriority,
 
         /// <summary>
+        /// FrameworkArgumentProcessor Help
+        /// </summary>
+        ResponseFileArgumentProcessorHelpPriority,
+
+        /// <summary>
         /// CLIRunSettingsArgumentProcessor Help
         /// </summary>
         CLIRunSettingsArgumentProcessorHelpPriority

--- a/src/vstest.console/Resources/Resources.Designer.cs
+++ b/src/vstest.console/Resources/Resources.Designer.cs
@@ -896,6 +896,17 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Error opening response file {0}
+        /// </summary>
+        public static string OpenResponseFileError
+        {
+            get
+            {
+                return ResourceManager.GetString("OpenResponseFileError", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to -o|--Output|/o|/Output:&lt;Output&gt;
         ///      The directory containing the binaries to run..
         /// </summary>
@@ -1002,6 +1013,18 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Resources {
             }
         }
         
+        /// <summary>
+        ///   Looks up a localized string similar to @&lt;file&gt;
+        ///      Read response file for more options.
+        /// </summary>
+        public static string ResponseFileArgumentHelp
+        {
+            get
+            {
+                return ResourceManager.GetString("ResponseFileArgumentHelp", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to --Settings|/Settings:&lt;Settings File&gt;
         ///      Settings to use when running tests..

--- a/src/vstest.console/Resources/Resources.resx
+++ b/src/vstest.console/Resources/Resources.resx
@@ -623,4 +623,11 @@
   <data name="MalformedRunSettingsKey" xml:space="preserve">
     <value>One or more runsettings provided contain invalid token</value>
   </data>
+  <data name="OpenResponseFileError" xml:space="preserve">
+    <value>Error opening response file '{0}'</value>
+  </data>
+  <data name="ResponseFileArgumentHelp" xml:space="preserve">
+    <value>@&lt;file&gt;
+      Read response file for more options.</value>
+  </data>
 </root>

--- a/test/Microsoft.TestPlatform.Utilities.UnitTests/CommandLineUtilitiesTest.cs
+++ b/test/Microsoft.TestPlatform.Utilities.UnitTests/CommandLineUtilitiesTest.cs
@@ -1,0 +1,53 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.TestPlatform.Utilities.Tests
+{
+    using System.Linq;
+
+    using Microsoft.VisualStudio.TestPlatform.Utilities;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    [TestClass]
+    public class CommandLineUtilitiesTest
+    {
+        /// <see href="https://github.com/dotnet/roslyn/blob/614299ff83da9959fa07131c6d0ffbc58873b6ae/src/Compilers/Core/CodeAnalysisTest/CommonCommandLineParserTests.cs#L14"/>
+        private void VerifyCommandLineSplitter(string commandLine, string[] expected, bool removeHashComments = false)
+        {
+            var actual = CommandLineUtilities.SplitCommandLineIntoArguments(commandLine, removeHashComments).ToArray();
+
+            Assert.AreEqual(expected.Length, actual.Length);
+            for (int i = 0; i < actual.Length; ++i)
+            {
+                Assert.AreEqual(expected[i], actual[i]);
+            }
+        }
+
+        /// <see href="https://github.com/dotnet/roslyn/blob/614299ff83da9959fa07131c6d0ffbc58873b6ae/src/Compilers/Core/CodeAnalysisTest/CommonCommandLineParserTests.cs#L83"/>
+        [TestMethod]
+        public void TestCommandLineSplitter()
+        {
+            VerifyCommandLineSplitter("", new string[0]);
+            VerifyCommandLineSplitter("   \t   ", new string[0]);
+            VerifyCommandLineSplitter("   abc\tdef baz    quuz   ", new[] { "abc", "def", "baz", "quuz" });
+            VerifyCommandLineSplitter(@"  ""abc def""  fi""ddle dee de""e  ""hi there ""dude  he""llo there""  ",
+                                        new string[] { @"abc def", @"fi""ddle dee de""e", @"""hi there ""dude", @"he""llo there""" });
+            VerifyCommandLineSplitter(@"  ""abc def \"" baz quuz"" ""\""straw berry"" fi\""zz \""buzz fizzbuzz",
+                                        new string[] { @"abc def \"" baz quuz", @"\""straw berry", @"fi\""zz", @"\""buzz", @"fizzbuzz" });
+            VerifyCommandLineSplitter(@"  \\""abc def""  \\\""abc def"" ",
+                                        new string[] { @"\\""abc def""", @"\\\""abc", @"def"" " });
+            VerifyCommandLineSplitter(@"  \\\\""abc def""  \\\\\""abc def"" ",
+                                        new string[] { @"\\\\""abc def""", @"\\\\\""abc", @"def"" " });
+            VerifyCommandLineSplitter(@"  \\\\""abc def""  \\\\\""abc def"" q a r ",
+                                        new string[] { @"\\\\""abc def""", @"\\\\\""abc", @"def"" q a r " });
+            VerifyCommandLineSplitter(@"abc #Comment ignored",
+                                        new string[] { @"abc" }, removeHashComments: true);
+            VerifyCommandLineSplitter(@"""foo bar"";""baz"" ""tree""",
+                                        new string[] { @"""foo bar"";""baz""", "tree" });
+            VerifyCommandLineSplitter(@"/reference:""a, b"" ""test""",
+                                        new string[] { @"/reference:""a, b""", "test" });
+            VerifyCommandLineSplitter(@"fo""o ba""r",
+                                        new string[] { @"fo""o ba""r" });
+        }
+    }
+}

--- a/test/vstest.console.UnitTests/ExecutorUnitTests.cs
+++ b/test/vstest.console.UnitTests/ExecutorUnitTests.cs
@@ -4,6 +4,7 @@
 namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests
 {
     using System.Collections.Generic;
+    using System.Globalization;
     using System.IO;
     using System.Linq;
 
@@ -108,6 +109,19 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests
             File.Delete(testSourceDllPath);
         }
 
+        [TestMethod]
+        public void ExecuteShouldExitWithErrorOnResponseFileException()
+        {
+            string[] args = { "@FileDoesNotExist.rsp" };
+            var mockOutput = new MockOutput();
+
+            var exitCode = new Executor(mockOutput, this.mockTestPlatformEventSource.Object).Execute(args);
+
+            var errorMessageCount = mockOutput.Messages.Count(msg => msg.Level == OutputLevel.Error && msg.Message.Contains(
+                string.Format(CultureInfo.CurrentCulture, CommandLineResources.OpenResponseFileError, args[0].Substring(1))));
+            Assert.AreEqual(1, errorMessageCount, "Response File Exception should display error.");
+            Assert.AreEqual(1, exitCode, "Response File Exception execution should exit with error.");
+        }
 
         private class MockOutput : IOutput
         {

--- a/test/vstest.console.UnitTests/Processors/ResponseFileArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/ResponseFileArgumentProcessorTests.cs
@@ -1,0 +1,52 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors
+{
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using TestPlatform.CommandLine.Processors;
+
+    [TestClass]
+    public class ResponseFileArgumentProcessorTests
+    {
+        [TestCleanup]
+        public void TestCleanup()
+        {
+            CommandLineOptions.Instance.Reset();
+        }
+
+        [TestMethod]
+        public void GetMetadataShouldReturnResponseFileArgumentProcessorCapabilities()
+        {
+            var processor = new ResponseFileArgumentProcessor();
+            Assert.IsTrue(processor.Metadata.Value is ResponseFileArgumentProcessorCapabilities);
+        }
+
+        [TestMethod]
+        public void GetExecuterShouldReturnNull()
+        {
+            var processor = new ResponseFileArgumentProcessor();
+            Assert.IsNull(processor.Executor);
+        }
+
+        #region ResponseFileArgumentProcessorCapabilities tests
+
+        [TestMethod]
+        public void CapabilitiesShouldReturnAppropriateProperties()
+        {
+            var capabilities = new ResponseFileArgumentProcessorCapabilities();
+            Assert.AreEqual("@", capabilities.CommandName);
+            StringAssert.Contains(capabilities.HelpContentResourceName, "Read response file for more options");
+
+            Assert.AreEqual(HelpContentPriority.ResponseFileArgumentProcessorHelpPriority, capabilities.HelpPriority);
+            Assert.AreEqual(false, capabilities.IsAction);
+            Assert.AreEqual(ArgumentProcessorPriority.Normal, capabilities.Priority);
+
+            Assert.AreEqual(true, capabilities.AllowMultiple);
+            Assert.AreEqual(false, capabilities.AlwaysExecute);
+            Assert.AreEqual(true, capabilities.IsSpecialCommand);
+        }
+
+        #endregion
+    }
+}


### PR DESCRIPTION
Response files that contain additional command line arguments may be
specified using the @<file> syntax similar to other Microsoft build
tools.

This enables over 8192 character command lines on Windows, which may be
necessary when testing a large number of assemblies.

Note that much of this code was lifted from the Roslyn repository, which
is copyright Microsoft but released on an Apache license.